### PR TITLE
Improve mobile styling for welcome and chefs sections

### DIFF
--- a/about.html
+++ b/about.html
@@ -88,6 +88,8 @@
                 display: block !important;
                 margin: 0 auto !important;
             }
+            /* Hide decorative top icon in welcome section on mobile to avoid overlay */
+            .welcome-part .icon-default { display: none !important; }
         }
         /* Chefs section styling */
         .chefs-section {
@@ -124,7 +126,8 @@
         @media (max-width: 576px) {
             .chefs-grid { grid-template-columns: 1fr; gap: 18px; }
             .chef-card img { width: 140px; height: 140px; }
-            .chefs-section { padding: 40px 0; }
+            .chefs-section { padding: 90px 0; }
+
         }
     </style>
 </head>


### PR DESCRIPTION
Hides the decorative top icon in the welcome section on mobile devices to prevent overlay issues and increases padding for the chefs section for better spacing on small screens.